### PR TITLE
Adds blank simulink IO files

### DIFF
--- a/simulink_input.csv
+++ b/simulink_input.csv
@@ -1,0 +1,2 @@
+Variable Name, Datatype, Minimum Value, Maximum Value, Name Description, Value Description
+DI_V_SteeringAngle, float, -1, 1, Steering wheel angle, "-1 is full left turn, +1 is full right turn. THIS IS JUST AN EXAMPLE"

--- a/simulink_output.csv
+++ b/simulink_output.csv
@@ -1,0 +1,1 @@
+Variable Name, Datatype, Minimum Value, Maximum Value, Name Description, Value Description


### PR DESCRIPTION
The simulink_input/output.csv files should be filled out by the controls team to describe the expected input and output values and datatypes. The firmware team will use these documents to pass record sensor values and pass into the simulink model.

Feel free to move the files into a different folder.

See simulink_input.csv for an example entry. Change as required.